### PR TITLE
Fixed close button to be used more than once

### DIFF
--- a/Data/Scripts/Main_Menu_Client.lua
+++ b/Data/Scripts/Main_Menu_Client.lua
@@ -86,8 +86,10 @@ local function on_button_pressed(button, row, txt)
 		local close_button = last_panel:FindDescendantByName("Close")
 
 		if(close_button ~= nil) then
-			close_button.pressedEvent:Connect(function()
+			local close_event_handler = nil;
+			close_event_handler = close_button.pressedEvent:Connect(function()
 				AUDIO:Play()
+				close_event_handler:Disconnect()
 				last_panel.visibility = Visibility.FORCE_OFF
 				last_panel = nil
 			end)

--- a/Data/Scripts/Main_Menu_Client.lua
+++ b/Data/Scripts/Main_Menu_Client.lua
@@ -86,7 +86,8 @@ local function on_button_pressed(button, row, txt)
 		local close_button = last_panel:FindDescendantByName("Close")
 
 		if(close_button ~= nil) then
-			local close_event_handler = nil;
+			local close_event_handler = nil
+
 			close_event_handler = close_button.pressedEvent:Connect(function()
 				AUDIO:Play()
 				close_event_handler:Disconnect()


### PR DESCRIPTION
The old close button handler was still active when pressing the close button the next time. This is now disconnected on use.